### PR TITLE
Add bump for tracking upstream updates + Action for checking + badge for bump

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,16 @@
+name: 'Automatic version updates'
+
+on:
+  schedule:
+    # minute hour dom month dow (UTC)
+    - cron: '00 15 * * *'
+  # enable manual trigger of version updates
+  workflow_dispatch:
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: ZOSOpenTools/meta/actions@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.BUMP_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-ctags
+[![Automatic version updates](https://github.com/ZOSOpenTools/ctagsport/actions/workflows/bump.yml/badge.svg)](https://github.com/ZOSOpenTools/ctagsport/actions/workflows/bump.yml)
+
+# ctags
 
 ctags generates an index (or tag) file of language objects found in source files for programming languages.

--- a/buildenv
+++ b/buildenv
@@ -1,8 +1,13 @@
-export ZOPEN_GIT_URL="git@github.com:universal-ctags/ctags.git"
-export ZOPEN_GIT_DEPS="git make gettext m4 autoconf automake zoslib"
-export ZOPEN_TARBALL_DEPS="make gzip tar"
-export ZOPEN_TARBALL_URL="https://src.fedoraproject.org/repo/pkgs/ctags/ctags-5.8.tar.gz/c00f82ecdcc357434731913e5b48630d/ctags-5.8.tar.gz"
-export ZOPEN_TYPE="TARBALL"
+# bump: ctags-version /CTAGS_VERSION="(.*)"/ https://github.com/universal-ctags/ctags.git|semver:*
+CTAGS_VERSION="6.0.0"
+
+export ZOPEN_BUILD_LINE="STABLE"
+export ZOPEN_DEV_URL="git@github.com:universal-ctags/ctags.git"
+export ZOPEN_DEV_DEPS="git make gettext m4 autoconf automake zoslib"
+export ZOPEN_STABLE_DEPS="make gzip tar"
+# export ZOPEN_STABLE_URL="https://src.fedoraproject.org/repo/pkgs/ctags/ctags-${CTAGS_VERSION}.tar.gz/c00f82ecdcc357434731913e5b48630d/ctags-${CTAGS_VERSION}.tar.gz"
+export ZOPEN_STABLE_URL="https://github.com/universal-ctags/ctags/releases/download/v${CTAGS_VERSION}/universal-ctags-${CTAGS_VERSION}.tar.gz"
+
 export ZOPEN_CHECK="./ctags"
 export ZOPEN_CHECK_OPTS="--verbose=yes -R ."
 
@@ -17,5 +22,4 @@ zopen_check_results()
   echo "actualFailures:$failures"
   echo "totalTests:1"
   echo "expectedFailures:0"
-  
 }


### PR DESCRIPTION
The current build is 5.8.
Note the URL change, as from 5.9 onwards, releases are available in GH.
So expect an automated PR for this from bump after this gets merged :)