### PR TITLE
Updated patches for version 6.2.1

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,5 +1,5 @@
 # bump: ctags-version /CTAGS_VERSION="(.*)"/ https://github.com/universal-ctags/ctags.git|semver:*
-CTAGS_VERSION="6.1.0"
+CTAGS_VERSION="6.2.1"
 
 export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_DEV_URL="https://github.com/universal-ctags/ctags.git"

--- a/patches/Makefile.am.patch
+++ b/patches/Makefile.am.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile.am b/Makefile.am
-index 72298929..bbd8036f 100644
+index 4f493d0..c70b98c 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -76,7 +76,7 @@ cc4b_verbose = $(cc4b_verbose_@AM_V@)
+@@ -83,7 +83,7 @@ cc4b_verbose = $(cc4b_verbose_@AM_V@)
  cc4b_verbose_ = $(cc4b_verbose_@AM_DEFAULT_V@)
  cc4b_verbose_0 = @echo CC4BUILD "  $@";
  $(PACKCC): $(srcdir)/$(PACKCC_SRC)

--- a/patches/acutest.h.patch
+++ b/patches/acutest.h.patch
@@ -1,13 +1,13 @@
 diff --git a/extra-cmds/acutest.h b/extra-cmds/acutest.h
-index 7c89b99f..b0144bb7 100644
+index 6eeced7..909b227 100644
 --- a/extra-cmds/acutest.h
 +++ b/extra-cmds/acutest.h
 @@ -281,7 +281,7 @@
  #include <string.h>
  #include <setjmp.h>
  
--#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
-+#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__) || defined(__MVS__)
+-#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__) || defined(__HAIKU__)
++#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__) || defined(__HAIKU__) || defined(__MVS__)
      #define ACUTEST_UNIX_       1
      #include <errno.h>
      #include <libgen.h>


### PR DESCRIPTION
Updated ctags version to 6.2.1, and fixed patches to be applied cleanly on this version.